### PR TITLE
More tolerant parsing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # vim: set sw=4 et:
 from setuptools import setup, find_packages
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 
 def load_requirements(filename):

--- a/tests/test_optional_flags_wacz.py
+++ b/tests/test_optional_flags_wacz.py
@@ -32,7 +32,7 @@ class TestWaczFormat(unittest.TestCase):
                         os.path.join(tmpdir, fp.name),
                     ]
                 ),
-                1,
+                0,
             )
 
     @patch("wacz.main.now")

--- a/wacz/main.py
+++ b/wacz/main.py
@@ -185,10 +185,7 @@ def create_wacz(res):
                 page_json = validateJSON(page_str)
 
                 if not page_json:
-                    print(
-                        "Warning: Ignoring invalid extra page\n %s"
-                        % page_str
-                    )
+                    print("Warning: Ignoring invalid extra page\n %s" % page_str)
                     continue
 
                 extra_page_data.append(page_str.encode("utf-8"))


### PR DESCRIPTION
- Don't fail on invalid pages.jsonl lines, print warning and ignore
- Fix parsing of http/https if string has no ':'
- bump to 0.4.3