### PR TITLE
Close ZIP once finished

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
       - name: checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
 
     steps:
       - name: checkout

--- a/wacz/main.py
+++ b/wacz/main.py
@@ -331,6 +331,8 @@ def create_wacz(res):
         wacz_indexer.generate_datapackage_digest(datapackage_bytes),
     )
 
+    wacz.close()
+
     return 0
 
 


### PR DESCRIPTION
It is important to close the ZIP once data is finished being written to
the WACZ or else some of the data may not be flushed to disk. This is
probably more important for usage of py-wacz as a library since the file
would automatically get flushed when it is used from the command line.

Fixes #20