### PR TITLE
Update README to fix --verifier-url param

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ New option in 0.4.0, this option also verifies the WACZ is signed, using [authsi
 
 The verification can be done locally, or via remote signing/verification server.
 
-To use remote server, add `--verify-url` which should be a URL pointing to the authsign `/verify` endpoint.
+To use remote server, add `--verifier-url` which should be a URL pointing to the authsign `/verify` endpoint.
 
 To run locally, the `authsign` must be installed, which can be done by running `pip install wacz[signing]`.
 


### PR DESCRIPTION
Its not `--verify-url`. The correct param name is `--verifier-url`.

Ref: https://github.com/webrecorder/py-wacz/blob/main/wacz/main.py#L101