### PR TITLE
Ignore hashtag on pages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # vim: set sw=4 et:
 from setuptools import setup, find_packages
 
-__version__ = "0.4.8"
+__version__ = "0.4.9"
 
 
 def load_requirements(filename):

--- a/tests/test_create_wacz_hash_in_page.py
+++ b/tests/test_create_wacz_hash_in_page.py
@@ -6,6 +6,7 @@ from frictionless import validate, Report
 
 TEST_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "fixtures")
 
+
 class TestWaczFor(unittest.TestCase):
     @classmethod
     @patch("wacz.main.now")
@@ -14,7 +15,9 @@ class TestWaczFor(unittest.TestCase):
         self.tmpdir = tempfile.TemporaryDirectory()
         with open(os.path.join(self.tmpdir.name, "test-pages.jsonl"), "wt") as fh:
             fh.write('{"format": "json-pages-1.0", "id": "pages", "title": "Pages"}\n')
-            fh.write('{"id": "abcdef", "url": "https://www.example.com/#hashtag", "title": "Example", "loadState": 4}\n')
+            fh.write(
+                '{"id": "abcdef", "url": "https://www.example.com/#hashtag", "title": "Example", "loadState": 4}\n'
+            )
 
         main(
             [
@@ -24,21 +27,32 @@ class TestWaczFor(unittest.TestCase):
                 "-p",
                 os.path.join(self.tmpdir.name, "test-pages.jsonl"),
                 "-o",
-                os.path.join(self.tmpdir.name, "example-custom-page.wacz")
+                os.path.join(self.tmpdir.name, "example-custom-page.wacz"),
             ]
         )
 
     def test_hash(self):
-        with zipfile.ZipFile(os.path.join(self.tmpdir.name, "example-custom-page.wacz"), "r") as zip_ref:
-            zip_ref.extract("pages/pages.jsonl", os.path.join(self.tmpdir.name, "extract-custom-page"))
+        with zipfile.ZipFile(
+            os.path.join(self.tmpdir.name, "example-custom-page.wacz"), "r"
+        ) as zip_ref:
+            zip_ref.extract(
+                "pages/pages.jsonl",
+                os.path.join(self.tmpdir.name, "extract-custom-page"),
+            )
             zip_ref.close()
 
-        with open(os.path.join(self.tmpdir.name, "extract-custom-page", "pages", "pages.jsonl"), "rt") as f:
+        with open(
+            os.path.join(
+                self.tmpdir.name, "extract-custom-page", "pages", "pages.jsonl"
+            ),
+            "rt",
+        ) as f:
             content = f.read()
 
-        assert content == """\
+        assert (
+            content
+            == """\
 {"format": "json-pages-1.0", "id": "pages", "title": "Pages"}
 {"id": "abcdef", "url": "https://www.example.com/#hashtag", "title": "Example", "loadState": 4, "ts": "2020-10-07T21:22:36Z"}
 """
-
-
+        )

--- a/tests/test_create_wacz_hash_in_page.py
+++ b/tests/test_create_wacz_hash_in_page.py
@@ -1,0 +1,44 @@
+import unittest, os, zipfile, sys, gzip, json, tempfile
+from wacz.main import main, now
+from unittest.mock import patch
+from wacz.util import hash_stream
+from frictionless import validate, Report
+
+TEST_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "fixtures")
+
+class TestWaczFor(unittest.TestCase):
+    @classmethod
+    @patch("wacz.main.now")
+    def setUpClass(self, mock_now):
+        mock_now.return_value = (2020, 10, 7, 22, 29, 10)
+        self.tmpdir = tempfile.TemporaryDirectory()
+        with open(os.path.join(self.tmpdir.name, "test-pages.jsonl"), "wt") as fh:
+            fh.write('{"format": "json-pages-1.0", "id": "pages", "title": "Pages"}\n')
+            fh.write('{"id": "abcdef", "url": "https://www.example.com/#hashtag", "title": "Example", "loadState": 4}\n')
+
+        main(
+            [
+                "create",
+                "-f",
+                os.path.join(TEST_DIR, "example-collection.warc"),
+                "-p",
+                os.path.join(self.tmpdir.name, "test-pages.jsonl"),
+                "-o",
+                os.path.join(self.tmpdir.name, "example-custom-page.wacz")
+            ]
+        )
+
+    def test_hash(self):
+        with zipfile.ZipFile(os.path.join(self.tmpdir.name, "example-custom-page.wacz"), "r") as zip_ref:
+            zip_ref.extract("pages/pages.jsonl", os.path.join(self.tmpdir.name, "extract-custom-page"))
+            zip_ref.close()
+
+        with open(os.path.join(self.tmpdir.name, "extract-custom-page", "pages", "pages.jsonl"), "rt") as f:
+            content = f.read()
+
+        assert content == """\
+{"format": "json-pages-1.0", "id": "pages", "title": "Pages"}
+{"id": "abcdef", "url": "https://www.example.com/#hashtag", "title": "Example", "loadState": 4, "ts": "2020-10-07T21:22:36Z"}
+"""
+
+

--- a/wacz/util.py
+++ b/wacz/util.py
@@ -74,6 +74,9 @@ def construct_passed_pages_dict(passed_pages_list):
         if "format" not in page_dict:
             url = page_dict.pop("url", "")
 
+            # strip out hashtag from page, will be matching URLs without it
+            url = url.split("#", 1)[0]
+
             # Set the default key as url
             key = url
 

--- a/wacz/util.py
+++ b/wacz/util.py
@@ -72,13 +72,11 @@ def construct_passed_pages_dict(passed_pages_list):
 
         # Skip the file's header if it's been set
         if "format" not in page_dict:
-            url = page_dict.pop("url", "")
+            url = page_dict.get("url", "")
 
-            # strip out hashtag from page, will be matching URLs without it
-            url = url.split("#", 1)[0]
-
-            # Set the default key as url
-            key = url
+            # Set the default key as url, but without hashtag, as will match pages
+            # to URLs without hashtag, but keep hashtag on page list
+            key = url.split("#", 1)[0]
 
             # If timestamp is present overwrite the key to be 'ts/url'
             if "ts" in page_dict:

--- a/wacz/waczindexer.py
+++ b/wacz/waczindexer.py
@@ -205,12 +205,13 @@ class WACZIndexer(CDXJIndexer):
         matched_id = check_http_and_https(url, ts, self.passed_pages_dict)
         # If we find a match build a record
         if matched_id:
-            new_page = {"timestamp": ts, "url": url, "title": url}
             input_page = self.passed_pages_dict[matched_id]
+            new_page = {
+                "timestamp": ts,
+                "url": input_page.get("url") or url,
+                "title": input_page.get("title") or url,
+            }
 
-            # Add title and text if they've been provided
-            if "title" in input_page:
-                new_page["title"] = input_page["title"]
             if "text" in self.passed_pages_dict[matched_id]:
                 new_page["text"] = input_page["text"]
 

--- a/wacz/waczindexer.py
+++ b/wacz/waczindexer.py
@@ -339,7 +339,6 @@ class WACZIndexer(CDXJIndexer):
 
             line["id"] = line.get("id") or line.get("page_id") or shortuuid.uuid()
 
-
             yield json.dumps(line) + "\n"
 
     def generate_datapackage(self, res, wacz):

--- a/wacz/waczindexer.py
+++ b/wacz/waczindexer.py
@@ -205,20 +205,17 @@ class WACZIndexer(CDXJIndexer):
         matched_id = check_http_and_https(url, ts, self.passed_pages_dict)
         # If we find a match build a record
         if matched_id:
-            input_page = self.passed_pages_dict[matched_id]
-            new_page = {
-                "timestamp": ts,
-                "url": input_page.get("url") or url,
-                "title": input_page.get("title") or url,
-            }
+            page_data = self.passed_pages_dict[matched_id]
+            page_data["timestamp"] = ts
+            if "url" not in page_data:
+                page_data["url"] = url
+            if "title" not in page_data:
+                page_data["title"] = url
 
-            if "text" in self.passed_pages_dict[matched_id]:
-                new_page["text"] = input_page["text"]
-
-            if self.split_seeds and not input_page.get("seed"):
-                self.extra_pages[matched_id] = new_page
+            if self.split_seeds and not page_data.get("seed"):
+                self.extra_pages[matched_id] = page_data
             else:
-                self.pages[matched_id] = new_page
+                self.pages[matched_id] = page_data
 
             # Delete the entry from our pages_dict so we can't match it again
             del self.passed_pages_dict[matched_id]
@@ -335,20 +332,15 @@ class WACZIndexer(CDXJIndexer):
         yield json.dumps(page_header) + "\n"
 
         for line in pages:
-            ts = timestamp_to_iso_date(line["timestamp"])
-            page_title = line.get("title")
+            if "ts" not in line and "timestamp" in line:
+                ts = timestamp_to_iso_date(line["timestamp"])
+                line["ts"] = ts
+                del line["timestamp"]
 
-            uid = line.get("id") or line.get("page_id") or shortuuid.uuid()
+            line["id"] = line.get("id") or line.get("page_id") or shortuuid.uuid()
 
-            data = {"id": uid, "url": line["url"], "ts": ts}
 
-            if page_title:
-                data["title"] = page_title
-
-            if "text" in line:
-                data["text"] = line["text"]
-
-            yield json.dumps(data) + "\n"
+            yield json.dumps(line) + "\n"
 
     def generate_datapackage(self, res, wacz):
         package_dict = {}


### PR DESCRIPTION
This PR allows matching of pages in a provided pages.jsonl to WARC records, ignoring the hashtag, eg. `https://example.com/#hashtag` is matched to WARC record `https://example.com/`. The page is added as `https://example.com/#hashtag` but the timestamp of the record without the hashtag is used.

bumps version 0.4.9